### PR TITLE
Separate exchange market cache, support additional alt markets

### DIFF
--- a/src/dali/plugin/pair_converter/ccxt.py
+++ b/src/dali/plugin/pair_converter/ccxt.py
@@ -17,7 +17,7 @@ from datetime import datetime, timedelta
 from time import sleep, time
 from typing import Any, Dict, List, NamedTuple, Optional, Union
 
-from ccxt import DDoSProtection, Exchange, ExchangeError, ExchangeNotAvailable, NetworkError, RequestTimeout, binance, cex, kraken, liquid, gateio, coinbase
+from ccxt import DDoSProtection, Exchange, ExchangeError, ExchangeNotAvailable, NetworkError, RequestTimeout, binance, kraken, liquid, gateio
 from rp2.logger import create_logger
 from rp2.rp2_decimal import RP2Decimal
 
@@ -41,15 +41,14 @@ _TIME_GRANULARITY: List[str] = [_MINUTE, _FIVE_MINUTE, _FIFTEEN_MINUTE, _ONE_HOU
 _TIME_GRANULARITY_IN_SECONDS: List[int] = [60, 300, 900, 3600, 14400, 86400]
 
 # Currently supported exchanges
+# NOTE coinbase currently (aug 2022) does not support the `fetchOHLCV()` method which is used here
 _BINANCE: str = "Binance.com"
-_CEX: str = "CEX.IO"
 _KRAKEN: str = "Kraken"
 _LIQUID: str = "Liquid"
 _GATE = "Gate"
-_COINBASE = "Coinbase"
 _FIAT_EXCHANGE: str = "Exchangerate.host"
 _DEFAULT_EXCHANGE: str = "Binance.com"
-_EXCHANGE_DICT: Dict[str, Any] = {_BINANCE: binance, _CEX: cex, _KRAKEN: kraken, _LIQUID: liquid, _GATE: gateio, _COINBASE: coinbase}
+_EXCHANGE_DICT: Dict[str, Any] = {_BINANCE: binance, _KRAKEN: kraken, _LIQUID: liquid, _GATE: gateio}
 
 # Delay in fractional seconds before making a request to avoid too many request errors
 # Kraken states it has a limit of 1 call per second, but this doesn't seem to be correct.
@@ -60,18 +59,16 @@ _REQUEST_DELAYDICT: Dict[str, float] = {_BINANCE: 0.0, _KRAKEN: 5.1, _LIQUID: 0}
 
 # Alternative Markets and exchanges for stablecoins or untradeable assets
 _ALTMARKET_EXCHANGES_DICT: Dict[str, str] = {
-    "GUSDUSD": _CEX,
     "SOLOXRP": _LIQUID,
     "USDTUSD": _KRAKEN,
     "SGBUSD": _KRAKEN,
     "ATDUSDT": _GATE,
     "BSVUSDT": _GATE,
-    "BOBAUSD": _COINBASE,
+    "BOBAUSD": _GATE,
     "EDGUSDT": _GATE,
 }
 
 _ALTMARKET_BY_BASE_DICT: Dict[str, str] = {
-    "GUSD": "USD",
     "SOLO": "XRP",
     "USDT": "USD",
     "ATD": "USDT",


### PR DESCRIPTION
* Supported additional alt markets
* This required me to add gateio exchange support
* Pulled out the exchange market cache into a separate method, this allows you to test the plugin via the console easily
* The caching being pulled into a separate method also allows for consistent initialization of a market, including the `"enableRateLimit": True` flag